### PR TITLE
Add Breakpoints + Fix Button bg color/styled system bug

### DIFF
--- a/src/__tests__/Button.js
+++ b/src/__tests__/Button.js
@@ -53,22 +53,22 @@ describe('Button', () => {
 
   it('renders primary color as default', () => {
     const { container } = render(<Button>APPLY</Button>);
-    expect(container.firstChild).toHaveStyle(`color: ${theme.button.primary.fontColor.default}`);
-    expect(container.firstChild).toHaveStyle(`background: ${theme.button.default(colors.hackBluePalette).bg.default}`);
+    expect(container.firstChild).toHaveStyle(`color: ${theme.buttons.primary.fontColor.default}`);
+    expect(container.firstChild).toHaveStyle(`background: ${theme.buttons.default(colors.hackBluePalette).bg.default}`);
   });
 
   it('renders correct border/bg/color with "outline" prop (primary colors)', () => {
     const { container } = render(<Button outline>APPLY</Button>);
-    expect(container.firstChild).toHaveStyle(`color: ${theme.button.default(colors.hackBluePalette).outline.fontColor.default}`);
-    expect(container.firstChild).toHaveStyle(`background: ${theme.button.default(colors.hackBluePalette).outline.bg.default}`);
-    expect(container.firstChild).toHaveStyle(`border: 2px solid ${theme.button.default(colors.hackBluePalette).outline.border.default}`);
+    expect(container.firstChild).toHaveStyle(`color: ${theme.buttons.default(colors.hackBluePalette).outline.fontColor.default}`);
+    expect(container.firstChild).toHaveStyle(`background: ${theme.buttons.default(colors.hackBluePalette).outline.bg.default}`);
+    expect(container.firstChild).toHaveStyle(`border: 2px solid ${theme.buttons.default(colors.hackBluePalette).outline.border.default}`);
   });
 
   it('renders correct colors with "outline" and "disabled" props (primary colors)', () => {
     const { container } = render(<Button disabled outline>APPLY</Button>);
-    expect(container.firstChild).toHaveStyle(`color: ${theme.button.default(colors.hackBluePalette).outline.fontColor.disabled}`);
-    expect(container.firstChild).toHaveStyle(`background: ${theme.button.default(colors.hackBluePalette).outline.bg.disabled}`);
-    expect(container.firstChild).toHaveStyle(`border: 2px solid ${theme.button.default(colors.hackBluePalette).outline.border.disabled}`);
+    expect(container.firstChild).toHaveStyle(`color: ${theme.buttons.default(colors.hackBluePalette).outline.fontColor.disabled}`);
+    expect(container.firstChild).toHaveStyle(`background: ${theme.buttons.default(colors.hackBluePalette).outline.bg.disabled}`);
+    expect(container.firstChild).toHaveStyle(`border: 2px solid ${theme.buttons.default(colors.hackBluePalette).outline.border.disabled}`);
 
     const item = renderJSON(<Button disabled outline />);
     expect(item).toMatchSnapshot();

--- a/src/__tests__/__snapshots__/Box.js.snap
+++ b/src/__tests__/__snapshots__/Box.js.snap
@@ -12,22 +12,22 @@ exports[`Box renders margin 1`] = `
 
 exports[`Box renders margin 2`] = `
 .c0 {
-  margin: 0;
+  margin: 0px;
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
   .c0 {
     margin: 4px;
   }
 }
 
-@media screen and (min-width:52em) {
+@media screen and (min-width:768px) {
   .c0 {
     margin: 8px;
   }
 }
 
-@media screen and (min-width:64em) {
+@media screen and (min-width:992px) {
   .c0 {
     margin: 16px;
   }
@@ -43,31 +43,31 @@ exports[`Box renders margin 3`] = `
   margin: 4px;
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
 
 }
 
-@media screen and (min-width:52em) {
+@media screen and (min-width:768px) {
 
 }
 
-@media screen and (min-width:64em) {
+@media screen and (min-width:992px) {
 
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
   .c0 {
     margin: 4px;
   }
 }
 
-@media screen and (min-width:52em) {
+@media screen and (min-width:768px) {
   .c0 {
     margin: 4px;
   }
 }
 
-@media screen and (min-width:64em) {
+@media screen and (min-width:992px) {
   .c0 {
     margin: 16px;
   }
@@ -90,22 +90,22 @@ exports[`Box renders padding 1`] = `
 
 exports[`Box renders padding 2`] = `
 .c0 {
-  padding: 0;
+  padding: 0px;
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
   .c0 {
     padding: 4px;
   }
 }
 
-@media screen and (min-width:52em) {
+@media screen and (min-width:768px) {
   .c0 {
     padding: 8px;
   }
 }
 
-@media screen and (min-width:64em) {
+@media screen and (min-width:992px) {
   .c0 {
     padding: 16px;
   }
@@ -121,31 +121,31 @@ exports[`Box renders padding 3`] = `
   padding: 4px;
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
 
 }
 
-@media screen and (min-width:52em) {
+@media screen and (min-width:768px) {
 
 }
 
-@media screen and (min-width:64em) {
+@media screen and (min-width:992px) {
 
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
   .c0 {
     padding: 4px;
   }
 }
 
-@media screen and (min-width:52em) {
+@media screen and (min-width:768px) {
   .c0 {
     padding: 4px;
   }
 }
 
-@media screen and (min-width:64em) {
+@media screen and (min-width:992px) {
   .c0 {
     padding: 16px;
   }
@@ -200,13 +200,13 @@ exports[`Box respects display 4`] = `
   display: none;
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
   .c0 {
     display: none;
   }
 }
 
-@media screen and (min-width:52em) {
+@media screen and (min-width:768px) {
   .c0 {
     display: block;
   }

--- a/src/__tests__/__snapshots__/Flex.js.snap
+++ b/src/__tests__/__snapshots__/Flex.js.snap
@@ -95,7 +95,7 @@ exports[`Flex respects responsive display 1`] = `
   display: flex;
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
   .c0 {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;

--- a/src/__tests__/__snapshots__/Grid.js.snap
+++ b/src/__tests__/__snapshots__/Grid.js.snap
@@ -149,7 +149,7 @@ exports[`Grid respects responsive display 1`] = `
   display: grid;
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:544px) {
   .c0 {
     display: inline-grid;
   }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import theme from '../../theme';
 import { get, lodashGet } from '../../utils/utils';
-import { COMMON } from '../../utils/constants';
+import { COMMON, COLOR } from '../../utils/constants';
 
 const ButtonBase = styled.button`
   // text
-  font-family: ${get('button.font')};
-  font-weight: ${get('button.fontWeight')};
-  font-size: ${get('button.fontSize')};
-  letter-spacing: ${get('button.letterSpacing')};
+  font-family: ${get('buttons.font')};
+  font-weight: ${get('buttons.fontWeight')};
+  font-size: ${get('buttons.fontSize')};
+  letter-spacing: ${get('buttons.letterSpacing')};
   text-decoration: none;
   text-transform: uppercase;
   overflow: hidden;
@@ -23,25 +23,27 @@ const ButtonBase = styled.button`
   height: 40px;
 
   // color
-  background: ${(props) => props.bg.default};
+  background: ${(props) => props.background.default};
   border: ${(props) => props.border.default};
   color: ${(props) => props.fontColor.default};
 
   // states
   &:hover:not([disabled]) {
-    background: ${(props) => props.bg.hover};
+    background: ${(props) => props.background.hover};
     border: ${(props) => props.border.hover};
     box-shadow: ${(props) => props.shadow.hover};
     color: ${(props) => props.fontColor.hover};
   }
 
   &:disabled {
-    background: ${(props) => props.bg.disabled};
+    background: ${(props) => props.background.disabled};
     border: ${(props) => props.border.disabled};
     box-shadow: ${(props) => props.shadow.disabled};
     color: ${(props) => props.fontColor.disabled};
   }
-  ${COMMON}
+
+  ${COMMON};
+  ${COLOR};
 `;
 
 const propTypes = {
@@ -53,6 +55,7 @@ const propTypes = {
   className: PropTypes.string,
   theme: PropTypes.object,
   ...COMMON.proptypes,
+  ...COLOR.proptypes,
 };
 
 const defaultProps = {
@@ -63,11 +66,11 @@ const defaultProps = {
 const Button = ({
   variant, outline, className, theme: propTheme, ...other
 }) => {
-  const buttonColorPalette = propTheme.colors.colorVariants[variant] || get('colors.colorVariants.primary');
-  const buttonTheme = propTheme.button[variant]; // || theme.button.default
-  const buttonDefaultTheme = propTheme.button.default(buttonColorPalette);
+  const buttonColorPalette = propTheme.colors.variants[variant] || get('colors.variants.primary');
+  const buttonTheme = propTheme.buttons[variant]; // || theme.button.default
+  const buttonDefaultTheme = propTheme.buttons.default(buttonColorPalette);
 
-  let bg = {
+  let background = {
     default: lodashGet(buttonTheme, 'bg.default', buttonDefaultTheme.bg.default),
     hover: lodashGet(buttonTheme, 'bg.hover', buttonDefaultTheme.bg.hover),
     disabled: lodashGet(buttonTheme, 'bg.disabled', buttonDefaultTheme.bg.disabled),
@@ -108,7 +111,7 @@ const Button = ({
       hover: lodashGet(buttonTheme, 'outline.fontColor.hover', defaultOutline.fontColor.hover),
       disabled: lodashGet(buttonTheme, 'outline.fontColor.disabled', defaultOutline.fontColor.disabled),
     };
-    bg = {
+    background = {
       default: lodashGet(buttonTheme, 'outline.bg.default', defaultOutline.bg.default),
       hover: lodashGet(buttonTheme, 'outline.bg.hover', defaultOutline.bg.hover),
       disabled: lodashGet(buttonTheme, 'outline.bg.disabled', defaultOutline.bg.disabled),
@@ -121,7 +124,15 @@ const Button = ({
   }
 
   const styling = {
-    bg,
+    // this (passed in as prop) must be named named `background` because you can
+    // not bg or backgroundColor
+    // because styled-system `color` uses it
+    // and it will think you passed it
+    // a background color... overriding the background
+    // color we want to set
+    // in this case, it will make the default background color
+    // the `lighter` color in the color pallette
+    background,
     border,
     fontColor,
     shadow,

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -6,10 +6,10 @@ import { get, lodashGet } from '../../utils/utils';
 import { COMMON, TYPOGRAPHY, COLOR } from '../../utils/constants';
 
 const LinkBase = styled.a`
-  font-family: ${get('button.font')};
-  font-weight: ${get('button.fontWeight')};
-  font-size: ${get('button.fontSize')};
-  letter-spacing: ${get('button.letterSpacing')};
+  font-family: ${get('buttons.font')};
+  font-weight: ${get('buttons.fontWeight')};
+  font-size: ${get('buttons.fontSize')};
+  letter-spacing: ${get('buttons.letterSpacing')};
 
   display: inline-block;
   padding: 0;
@@ -41,14 +41,14 @@ const LinkBase = styled.a`
 const Link = ({
   color, hoverColor, variant, theme: propTheme, ...other
 }) => {
-  let linkColor = color || propTheme.colors.colorVariants.primary.primary;
-  let linkHoverColor = hoverColor || propTheme.colors.colorVariants.primary.dark;
+  let linkColor = color || propTheme.colors.variants.primary.primary;
+  let linkHoverColor = hoverColor || propTheme.colors.variants.primary.dark;
 
   // if variant, change color
   // but don't override color,hoverColor props, if given
   if (variant) {
     const linkTheme = propTheme.link[variant];
-    const defaultLinkTheme = propTheme.link.default(propTheme.colors.colorVariants[variant] || get('colors.colorVariants.primary'));
+    const defaultLinkTheme = propTheme.link.default(propTheme.colors.variants[variant] || get('colors.variants.primary'));
     if (!color) {
       linkColor = lodashGet(linkTheme, 'color.default', defaultLinkTheme.color.default);
     }

--- a/src/theme.js
+++ b/src/theme.js
@@ -101,7 +101,7 @@ const colors = {
     },
   },
   // states or in other words color variants
-  colorVariants: {
+  variants: {
     primary: hackBluePalette,
     success: greenPalette,
     error: redPalette,
@@ -130,7 +130,7 @@ const fontWeights = {
 };
 
 // styling specific to the Button component
-const button = {
+const buttons = {
   font: fonts.secondary,
   fontWeight: fontWeights.bold,
   fontSize: '14px',
@@ -254,15 +254,20 @@ const link = {
   },
 };
 
+const breakpoints = ['544px', '768px', '992px', '1280px'];
+breakpoints.xs = breakpoints[0];
+breakpoints.sm = breakpoints[1];
+breakpoints.md = breakpoints[2];
+breakpoints.lg = breakpoints[3];
 
-const spacing = ['0px', '4px', '8px', '16px', '32px', '64px', '128px'];
-spacing.none = spacing[0];
-spacing.xxs = spacing[1];
-spacing.xs = spacing[2];
-spacing.sm = spacing[3];
-spacing.md = spacing[4];
-spacing.lg = spacing[5];
-spacing.xl = spacing[6];
+const space = ['0px', '4px', '8px', '16px', '32px', '64px', '128px'];
+space.none = space[0];
+space.xxs = space[1];
+space.xs = space[2];
+space.sm = space[3];
+space.md = space[4];
+space.lg = space[5];
+space.xl = space[6];
 
 const theme = {
   // General
@@ -270,9 +275,11 @@ const theme = {
   fonts,
   fontWeights,
   fontSizes,
-  button,
+  buttons,
   link,
   DEFAULT_SHADOW,
+  space,
+  breakpoints,
 };
 
 


### PR DESCRIPTION
Button Background Color bug
    - styled system uses `bg` or `backgroundColor`props, so when we passed `bg` to `ButtonBase` for our custom color (logic for the variants) it would set the background-color to the lighter color of the color palette - this would override the default css tag `background` we initially set (you want the `color` props to override the colors we set since that's user set)